### PR TITLE
feature: add click fold & unfold feature to move dirs

### DIFF
--- a/src/app/workspace/forms/move-item-form.component.html
+++ b/src/app/workspace/forms/move-item-form.component.html
@@ -14,14 +14,16 @@
 
           <ng-template #pobjectItem let-dest let-depth="depth">
             <li class="pobject" *ngIf="dest.type === 'directory' && canMove(pobject, dest)">
-              <div class="move-item" (click)="target = dest" [ngClass]="{'active': target === dest}">
+              <div class="move-item" (click)="target = dest; dest.openMove = !dest.openMove" [ngClass]="{'active': target === dest}">
                 <div class="row">
                   <div class="col-xs-12">
-                    <span class="title" [ngStyle]="{'margin-left.px': Math.max(0, (depth-1) * 30).toString() }"><span class="glyphicon glyphicon-folder-open"></span> {{dest.title}}</span>
+                    <span class="title" [ngStyle]="{'margin-left.px': Math.max(0, (depth-1) * 30).toString() }">
+                      <span class="glyphicon" [ngClass]="dest.openMove ? 'glyphicon-folder-open' : 'glyphicon-folder-close'"></span> {{dest.title}}</span>
+                      <span *ngIf="dest.openMove && dest.pobjects.length === 0">(empty)</span>
                   </div>
                 </div>
               </div>
-              <ul class="pobject-list subgroup">
+              <ul class="pobject-list subgroup" *ngIf="dest.openMove">
                 <ng-container *ngFor="let item of dest.pobjects">
                   <ng-container *ngTemplateOutlet="pobjectItem; context:{$implicit: item, depth: depth + 1}"></ng-container>
                 </ng-container>

--- a/src/app/workspace/pages/files.component.ts
+++ b/src/app/workspace/pages/files.component.ts
@@ -232,6 +232,7 @@ export class FilesComponent implements OnInit {
         this.rootDir = success;
         this.createPublicUrls(this.rootDir);
         this.rootDir.open = true;
+        this.rootDir.openMove = true;
       });
   }
 


### PR DESCRIPTION
Added the same functionality to fold or unfold directories in the "Move" modal, as it exists in the files panel.

Another field had to be created (`openMove`) otherwise the clicks would reflect the changes in both panels, the "Move" modal and the files panel behind.