### PR TITLE
feature: add delete & rename dir for shared dirs

### DIFF
--- a/src/app/workspace/pages/files.component.ts
+++ b/src/app/workspace/pages/files.component.ts
@@ -290,10 +290,10 @@ export class FilesComponent implements OnInit {
         let directoryInOwnFiles = this.getPobjectById(id, this.getRoot());
         let directoryInSharedFiles = this.getPobjectById(id, this.getShared());
         if (directoryInOwnFiles) {
-          this.deletePobjectById(id, this.rootDir);
+          this.deletePobjectById(id, this.getRoot());
         }
         if (directoryInSharedFiles) {
-          this.deletePobjectById(id, this.sharedDir);
+          this.deletePobjectById(id, this.getShared());
         }
         this.triggerLocalStorageChangeEvent();
         this.toastr.success('Directory deleted');

--- a/src/app/workspace/pages/files.component.ts
+++ b/src/app/workspace/pages/files.component.ts
@@ -287,7 +287,14 @@ export class FilesComponent implements OnInit {
   deleteDirectoryREST(id) {
     this.http.delete(config.backend.host + '/rest/directories/' + id, AuthService.loadRequestOptions()).subscribe(
       success => {
-        this.deletePobjectById(id, this.rootDir);
+        let directoryInOwnFiles = this.getPobjectById(id, this.getRoot());
+        let directoryInSharedFiles = this.getPobjectById(id, this.getShared());
+        if (directoryInOwnFiles) {
+          this.deletePobjectById(id, this.rootDir);
+        }
+        if (directoryInSharedFiles) {
+          this.deletePobjectById(id, this.sharedDir);
+        }
         this.triggerLocalStorageChangeEvent();
         this.toastr.success('Directory deleted');
       },
@@ -428,7 +435,8 @@ export class FilesComponent implements OnInit {
   }
 
   renameDirectory(oldDirectoryId, title) {
-    let oldDirectory = this.getPobjectById(Number.parseInt(oldDirectoryId), this.getRoot());
+    let directoryInOwnFiles = this.getPobjectById(Number.parseInt(oldDirectoryId), this.getRoot());
+    let oldDirectory = directoryInOwnFiles ? directoryInOwnFiles : this.getPobjectById(Number.parseInt(oldDirectoryId), this.getShared());
     let newDirectory = Object.assign({}, oldDirectory);
     newDirectory.title = title;
     // sending generic classes as JSON to java is not smart enough, TODO: get better JSON<->POJO lib?
@@ -1095,7 +1103,8 @@ export class FilesComponent implements OnInit {
   }
 
   initRenameDirectoryModal(id) {
-    let directory = this.getPobjectById(id, this.getRoot());
+    let directoryInOwnFiles = this.getPobjectById(id, this.getRoot());
+    let directory = directoryInOwnFiles ? directoryInOwnFiles : this.getPobjectById(id, this.getShared());
     $('.directory-name-input').removeClass('has-error');
     $('.directory-name-error').hide();
     $('#renameDirectoryModal').find('.renameDirectoryParentId').val(id);
@@ -1121,7 +1130,8 @@ export class FilesComponent implements OnInit {
   }
 
   initDeleteDirectoryModal(id) {
-    let directory = this.getPobjectById(id, this.getRoot());
+    let directoryInOwnFiles = this.getPobjectById(id, this.getRoot());
+    let directory = directoryInOwnFiles ? directoryInOwnFiles : this.getPobjectById(id, this.getShared());
     $('#deleteDirectoryModal').find('.deleteDirectoryParentId').val(id);
     $('#deleteDirectoryModal').find('.deleteDirectoryTitle').text(directory.title);
     $('#deleteDirectoryModal').modal();

--- a/src/app/workspace/templates/sharedFiles.component.html
+++ b/src/app/workspace/templates/sharedFiles.component.html
@@ -93,6 +93,12 @@
             <li *ngIf="parent.canCreateDirectory(pobject)">
               <a (click)="parent.initCreateNewDirectoryModal(pobject.id)">New directory</a>
             </li>
+            <li *ngIf="parent.canRenameDirectory(pobject)">
+              <a (click)="parent.initRenameDirectoryModal(pobject.id)">Rename</a>
+            </li>
+            <li *ngIf="parent.canDeleteDirectory(pobject)">
+              <a (click)="parent.initDeleteDirectoryModal(pobject.id)">Delete</a>
+            </li>
             <li *ngIf="parent.canShare(pobject)" role="separator" class="divider"></li>
             <li *ngIf="parent.canShare(pobject)">
               <a (click)="parent.openShareItemModal(pobject)">Share</a>


### PR DESCRIPTION
Added `delete` and `rename` features to shared directories that fall under similar circumstances as:
> Folder is created by X and subfolder by Y. Neither X nor Y are able to delete/rename the subfolder.

Now Y can delete/rename the subfolder.

However, there are still some related behaviors of shared folders for which the current permissions' logic fails, both in the frontend and backend.
The `move` functionality also suffers from this strange permissions' logic and because of that I decided not to include it.
There may be the need for a more thorough discussion to determine what else to implement and the desired behavior of this type of functionalities that target shared objects.
